### PR TITLE
Update Powersupply runtime to 46

### DIFF
--- a/nl.brixit.powersupply.json
+++ b/nl.brixit.powersupply.json
@@ -1,7 +1,7 @@
 {
     "app-id": "nl.brixit.powersupply",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "powersupply",
     "finish-args": [


### PR DESCRIPTION
- Update Powersuply runtime to 46 since runtime version 44 has reached end-of-life.